### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,8 @@
 name: Build
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main", "dev" ]


### PR DESCRIPTION
Potential fix for [https://github.com/jeroenzeelmaekers/simls/security/code-scanning/1](https://github.com/jeroenzeelmaekers/simls/security/code-scanning/1)

To fix the issue, you should explicitly specify the minimum required permissions for the workflow. This can be done at either the workflow level or for individual jobs. As this workflow performs a simple `checkout` and `build` operation, only `contents: read` permission is required. The fix involves adding a `permissions:` block either at the workflow root (recommended, for simplicity) or within the `build` job definition. Add this block above the `jobs:` section in `.github/workflows/build.yml` as follows:

```yaml
permissions:
  contents: read
```

No method or import changes are required, only this configuration addition to the YAML workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
